### PR TITLE
Create Long Files for Conflict Testing

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1,0 +1,287 @@
+"""
+Long engine module for conflict testing.
+Use the explicit [SEC X START/END] anchors below for deterministic edits.
+"""
+
+# [SEC A START] Setup
+PORT = 3000
+MODE = "dev"
+# SEC A filler 001
+# SEC A filler 002
+# SEC A filler 003
+# SEC A filler 004
+# SEC A filler 005
+# SEC A filler 006
+# SEC A filler 007
+# SEC A filler 008
+# SEC A filler 009
+# SEC A filler 010
+# SEC A filler 011
+# SEC A filler 012
+# SEC A filler 013
+# SEC A filler 014
+# SEC A filler 015
+# SEC A filler 016
+# SEC A filler 017
+# SEC A filler 018
+# SEC A filler 019
+# SEC A filler 020
+# SEC A filler 021
+# SEC A filler 022
+# SEC A filler 023
+# SEC A filler 024
+# SEC A filler 025
+# SEC A filler 026
+# SEC A filler 027
+# SEC A filler 028
+# SEC A filler 029
+# SEC A filler 030
+# [SEC A END]
+
+# [SEC B START] Greetings
+GREETING = "Hello v1"
+def greet(name):
+    return f"{GREETING}, {name}"
+# SEC B filler 001
+# SEC B filler 002
+# SEC B filler 003
+# SEC B filler 004
+# SEC B filler 005
+# SEC B filler 006
+# SEC B filler 007
+# SEC B filler 008
+# SEC B filler 009
+# SEC B filler 010
+# SEC B filler 011
+# SEC B filler 012
+# SEC B filler 013
+# SEC B filler 014
+# SEC B filler 015
+# SEC B filler 016
+# SEC B filler 017
+# SEC B filler 018
+# SEC B filler 019
+# SEC B filler 020
+# SEC B filler 021
+# SEC B filler 022
+# SEC B filler 023
+# SEC B filler 024
+# SEC B filler 025
+# SEC B filler 026
+# SEC B filler 027
+# SEC B filler 028
+# SEC B filler 029
+# SEC B filler 030
+# [SEC B END]
+
+# [SEC C START] Math helpers
+def add(a, b):
+    return a + b
+# SEC C filler 001
+# SEC C filler 002
+# SEC C filler 003
+# SEC C filler 004
+# SEC C filler 005
+# SEC C filler 006
+# SEC C filler 007
+# SEC C filler 008
+# SEC C filler 009
+# SEC C filler 010
+# SEC C filler 011
+# SEC C filler 012
+# SEC C filler 013
+# SEC C filler 014
+# SEC C filler 015
+# SEC C filler 016
+# SEC C filler 017
+# SEC C filler 018
+# SEC C filler 019
+# SEC C filler 020
+# SEC C filler 021
+# SEC C filler 022
+# SEC C filler 023
+# SEC C filler 024
+# SEC C filler 025
+# SEC C filler 026
+# SEC C filler 027
+# SEC C filler 028
+# SEC C filler 029
+# SEC C filler 030
+# [SEC C END]
+
+# [SEC D START] Logger
+LEVEL = "INFO"
+def get_logger():
+    fmt = "[%(levelname)s] %(message)s"
+    return (LEVEL, fmt)
+# SEC D filler 001
+# SEC D filler 002
+# SEC D filler 003
+# SEC D filler 004
+# SEC D filler 005
+# SEC D filler 006
+# SEC D filler 007
+# SEC D filler 008
+# SEC D filler 009
+# SEC D filler 010
+# SEC D filler 011
+# SEC D filler 012
+# SEC D filler 013
+# SEC D filler 014
+# SEC D filler 015
+# SEC D filler 016
+# SEC D filler 017
+# SEC D filler 018
+# SEC D filler 019
+# SEC D filler 020
+# SEC D filler 021
+# SEC D filler 022
+# SEC D filler 023
+# SEC D filler 024
+# SEC D filler 025
+# SEC D filler 026
+# SEC D filler 027
+# SEC D filler 028
+# SEC D filler 029
+# SEC D filler 030
+# [SEC D END]
+
+# [SEC E START] Versioning
+VERSION = "1.0.0"
+def compute_version():
+    return VERSION
+# SEC E filler 001
+# SEC E filler 002
+# SEC E filler 003
+# SEC E filler 004
+# SEC E filler 005
+# SEC E filler 006
+# SEC E filler 007
+# SEC E filler 008
+# SEC E filler 009
+# SEC E filler 010
+# SEC E filler 011
+# SEC E filler 012
+# SEC E filler 013
+# SEC E filler 014
+# SEC E filler 015
+# SEC E filler 016
+# SEC E filler 017
+# SEC E filler 018
+# SEC E filler 019
+# SEC E filler 020
+# SEC E filler 021
+# SEC E filler 022
+# SEC E filler 023
+# SEC E filler 024
+# SEC E filler 025
+# SEC E filler 026
+# SEC E filler 027
+# SEC E filler 028
+# SEC E filler 029
+# SEC E filler 030
+# [SEC E END]
+
+# [SEC F START] Flags
+FEATURE_X = False
+# SEC F filler 001
+# SEC F filler 002
+# SEC F filler 003
+# SEC F filler 004
+# SEC F filler 005
+# SEC F filler 006
+# SEC F filler 007
+# SEC F filler 008
+# SEC F filler 009
+# SEC F filler 010
+# SEC F filler 011
+# SEC F filler 012
+# SEC F filler 013
+# SEC F filler 014
+# SEC F filler 015
+# SEC F filler 016
+# SEC F filler 017
+# SEC F filler 018
+# SEC F filler 019
+# SEC F filler 020
+# SEC F filler 021
+# SEC F filler 022
+# SEC F filler 023
+# SEC F filler 024
+# SEC F filler 025
+# SEC F filler 026
+# SEC F filler 027
+# SEC F filler 028
+# SEC F filler 029
+# SEC F filler 030
+# [SEC F END]
+
+# [SEC G START] IO helpers
+def write_file(p, text):
+    open(p, "w").write(text)
+# SEC G filler 001
+# SEC G filler 002
+# SEC G filler 003
+# SEC G filler 004
+# SEC G filler 005
+# SEC G filler 006
+# SEC G filler 007
+# SEC G filler 008
+# SEC G filler 009
+# SEC G filler 010
+# SEC G filler 011
+# SEC G filler 012
+# SEC G filler 013
+# SEC G filler 014
+# SEC G filler 015
+# SEC G filler 016
+# SEC G filler 017
+# SEC G filler 018
+# SEC G filler 019
+# SEC G filler 020
+# SEC G filler 021
+# SEC G filler 022
+# SEC G filler 023
+# SEC G filler 024
+# SEC G filler 025
+# SEC G filler 026
+# SEC G filler 027
+# SEC G filler 028
+# SEC G filler 029
+# SEC G filler 030
+# [SEC G END]
+
+# [SEC H START] Main
+if __name__ == "__main__":
+    print(greet("world"))
+# SEC H filler 001
+# SEC H filler 002
+# SEC H filler 003
+# SEC H filler 004
+# SEC H filler 005
+# SEC H filler 006
+# SEC H filler 007
+# SEC H filler 008
+# SEC H filler 009
+# SEC H filler 010
+# SEC H filler 011
+# SEC H filler 012
+# SEC H filler 013
+# SEC H filler 014
+# SEC H filler 015
+# SEC H filler 016
+# SEC H filler 017
+# SEC H filler 018
+# SEC H filler 019
+# SEC H filler 020
+# SEC H filler 021
+# SEC H filler 022
+# SEC H filler 023
+# SEC H filler 024
+# SEC H filler 025
+# SEC H filler 026
+# SEC H filler 027
+# SEC H filler 028
+# SEC H filler 029
+# SEC H filler 030
+# [SEC H END]

--- a/handbook.md
+++ b/handbook.md
@@ -1,0 +1,282 @@
+---
+title: "Engineering Handbook"
+version: 1
+---
+
+# Chapter 1: Onboarding
+- Create account
+- Set up SSH
+- Run first build
+<!-- Ch1 filler 001 -->
+<!-- Ch1 filler 002 -->
+<!-- Ch1 filler 003 -->
+<!-- Ch1 filler 004 -->
+<!-- Ch1 filler 005 -->
+<!-- Ch1 filler 006 -->
+<!-- Ch1 filler 007 -->
+<!-- Ch1 filler 008 -->
+<!-- Ch1 filler 009 -->
+<!-- Ch1 filler 010 -->
+<!-- Ch1 filler 011 -->
+<!-- Ch1 filler 012 -->
+<!-- Ch1 filler 013 -->
+<!-- Ch1 filler 014 -->
+<!-- Ch1 filler 015 -->
+<!-- Ch1 filler 016 -->
+<!-- Ch1 filler 017 -->
+<!-- Ch1 filler 018 -->
+<!-- Ch1 filler 019 -->
+<!-- Ch1 filler 020 -->
+<!-- Ch1 filler 021 -->
+<!-- Ch1 filler 022 -->
+<!-- Ch1 filler 023 -->
+<!-- Ch1 filler 024 -->
+<!-- Ch1 filler 025 -->
+<!-- Ch1 filler 026 -->
+<!-- Ch1 filler 027 -->
+<!-- Ch1 filler 028 -->
+<!-- Ch1 filler 029 -->
+<!-- Ch1 filler 030 -->
+
+# Chapter 2: Coding Standards
+- Use black/ruff
+- 100-col limit
+- Docstrings required
+<!-- Ch2 filler 001 -->
+<!-- Ch2 filler 002 -->
+<!-- Ch2 filler 003 -->
+<!-- Ch2 filler 004 -->
+<!-- Ch2 filler 005 -->
+<!-- Ch2 filler 006 -->
+<!-- Ch2 filler 007 -->
+<!-- Ch2 filler 008 -->
+<!-- Ch2 filler 009 -->
+<!-- Ch2 filler 010 -->
+<!-- Ch2 filler 011 -->
+<!-- Ch2 filler 012 -->
+<!-- Ch2 filler 013 -->
+<!-- Ch2 filler 014 -->
+<!-- Ch2 filler 015 -->
+<!-- Ch2 filler 016 -->
+<!-- Ch2 filler 017 -->
+<!-- Ch2 filler 018 -->
+<!-- Ch2 filler 019 -->
+<!-- Ch2 filler 020 -->
+<!-- Ch2 filler 021 -->
+<!-- Ch2 filler 022 -->
+<!-- Ch2 filler 023 -->
+<!-- Ch2 filler 024 -->
+<!-- Ch2 filler 025 -->
+<!-- Ch2 filler 026 -->
+<!-- Ch2 filler 027 -->
+<!-- Ch2 filler 028 -->
+<!-- Ch2 filler 029 -->
+<!-- Ch2 filler 030 -->
+
+# Chapter 3: Branching Strategy
+- main is protected
+- feature branches from main
+- rebase before merge
+<!-- Ch3 filler 001 -->
+<!-- Ch3 filler 002 -->
+<!-- Ch3 filler 003 -->
+<!-- Ch3 filler 004 -->
+<!-- Ch3 filler 005 -->
+<!-- Ch3 filler 006 -->
+<!-- Ch3 filler 007 -->
+<!-- Ch3 filler 008 -->
+<!-- Ch3 filler 009 -->
+<!-- Ch3 filler 010 -->
+<!-- Ch3 filler 011 -->
+<!-- Ch3 filler 012 -->
+<!-- Ch3 filler 013 -->
+<!-- Ch3 filler 014 -->
+<!-- Ch3 filler 015 -->
+<!-- Ch3 filler 016 -->
+<!-- Ch3 filler 017 -->
+<!-- Ch3 filler 018 -->
+<!-- Ch3 filler 019 -->
+<!-- Ch3 filler 020 -->
+<!-- Ch3 filler 021 -->
+<!-- Ch3 filler 022 -->
+<!-- Ch3 filler 023 -->
+<!-- Ch3 filler 024 -->
+<!-- Ch3 filler 025 -->
+<!-- Ch3 filler 026 -->
+<!-- Ch3 filler 027 -->
+<!-- Ch3 filler 028 -->
+<!-- Ch3 filler 029 -->
+<!-- Ch3 filler 030 -->
+
+# Chapter 4: Code Review
+- 2 approvals
+- Address comments
+- CI green
+<!-- Ch4 filler 001 -->
+<!-- Ch4 filler 002 -->
+<!-- Ch4 filler 003 -->
+<!-- Ch4 filler 004 -->
+<!-- Ch4 filler 005 -->
+<!-- Ch4 filler 006 -->
+<!-- Ch4 filler 007 -->
+<!-- Ch4 filler 008 -->
+<!-- Ch4 filler 009 -->
+<!-- Ch4 filler 010 -->
+<!-- Ch4 filler 011 -->
+<!-- Ch4 filler 012 -->
+<!-- Ch4 filler 013 -->
+<!-- Ch4 filler 014 -->
+<!-- Ch4 filler 015 -->
+<!-- Ch4 filler 016 -->
+<!-- Ch4 filler 017 -->
+<!-- Ch4 filler 018 -->
+<!-- Ch4 filler 019 -->
+<!-- Ch4 filler 020 -->
+<!-- Ch4 filler 021 -->
+<!-- Ch4 filler 022 -->
+<!-- Ch4 filler 023 -->
+<!-- Ch4 filler 024 -->
+<!-- Ch4 filler 025 -->
+<!-- Ch4 filler 026 -->
+<!-- Ch4 filler 027 -->
+<!-- Ch4 filler 028 -->
+<!-- Ch4 filler 029 -->
+<!-- Ch4 filler 030 -->
+
+# Chapter 5: Release Process
+- bump version
+- tag release
+- publish artifacts
+<!-- Ch5 filler 001 -->
+<!-- Ch5 filler 002 -->
+<!-- Ch5 filler 003 -->
+<!-- Ch5 filler 004 -->
+<!-- Ch5 filler 005 -->
+<!-- Ch5 filler 006 -->
+<!-- Ch5 filler 007 -->
+<!-- Ch5 filler 008 -->
+<!-- Ch5 filler 009 -->
+<!-- Ch5 filler 010 -->
+<!-- Ch5 filler 011 -->
+<!-- Ch5 filler 012 -->
+<!-- Ch5 filler 013 -->
+<!-- Ch5 filler 014 -->
+<!-- Ch5 filler 015 -->
+<!-- Ch5 filler 016 -->
+<!-- Ch5 filler 017 -->
+<!-- Ch5 filler 018 -->
+<!-- Ch5 filler 019 -->
+<!-- Ch5 filler 020 -->
+<!-- Ch5 filler 021 -->
+<!-- Ch5 filler 022 -->
+<!-- Ch5 filler 023 -->
+<!-- Ch5 filler 024 -->
+<!-- Ch5 filler 025 -->
+<!-- Ch5 filler 026 -->
+<!-- Ch5 filler 027 -->
+<!-- Ch5 filler 028 -->
+<!-- Ch5 filler 029 -->
+<!-- Ch5 filler 030 -->
+
+# Chapter 6: Incident Response
+- SEV1 page immediately
+- RCA within 72h
+- Postmortem doc
+<!-- Ch6 filler 001 -->
+<!-- Ch6 filler 002 -->
+<!-- Ch6 filler 003 -->
+<!-- Ch6 filler 004 -->
+<!-- Ch6 filler 005 -->
+<!-- Ch6 filler 006 -->
+<!-- Ch6 filler 007 -->
+<!-- Ch6 filler 008 -->
+<!-- Ch6 filler 009 -->
+<!-- Ch6 filler 010 -->
+<!-- Ch6 filler 011 -->
+<!-- Ch6 filler 012 -->
+<!-- Ch6 filler 013 -->
+<!-- Ch6 filler 014 -->
+<!-- Ch6 filler 015 -->
+<!-- Ch6 filler 016 -->
+<!-- Ch6 filler 017 -->
+<!-- Ch6 filler 018 -->
+<!-- Ch6 filler 019 -->
+<!-- Ch6 filler 020 -->
+<!-- Ch6 filler 021 -->
+<!-- Ch6 filler 022 -->
+<!-- Ch6 filler 023 -->
+<!-- Ch6 filler 024 -->
+<!-- Ch6 filler 025 -->
+<!-- Ch6 filler 026 -->
+<!-- Ch6 filler 027 -->
+<!-- Ch6 filler 028 -->
+<!-- Ch6 filler 029 -->
+<!-- Ch6 filler 030 -->
+
+# Chapter 7: Glossary
+- CI: Continuous Integration
+- CD: Continuous Delivery
+<!-- Ch7 filler 001 -->
+<!-- Ch7 filler 002 -->
+<!-- Ch7 filler 003 -->
+<!-- Ch7 filler 004 -->
+<!-- Ch7 filler 005 -->
+<!-- Ch7 filler 006 -->
+<!-- Ch7 filler 007 -->
+<!-- Ch7 filler 008 -->
+<!-- Ch7 filler 009 -->
+<!-- Ch7 filler 010 -->
+<!-- Ch7 filler 011 -->
+<!-- Ch7 filler 012 -->
+<!-- Ch7 filler 013 -->
+<!-- Ch7 filler 014 -->
+<!-- Ch7 filler 015 -->
+<!-- Ch7 filler 016 -->
+<!-- Ch7 filler 017 -->
+<!-- Ch7 filler 018 -->
+<!-- Ch7 filler 019 -->
+<!-- Ch7 filler 020 -->
+<!-- Ch7 filler 021 -->
+<!-- Ch7 filler 022 -->
+<!-- Ch7 filler 023 -->
+<!-- Ch7 filler 024 -->
+<!-- Ch7 filler 025 -->
+<!-- Ch7 filler 026 -->
+<!-- Ch7 filler 027 -->
+<!-- Ch7 filler 028 -->
+<!-- Ch7 filler 029 -->
+<!-- Ch7 filler 030 -->
+
+# Chapter 8: FAQ
+- Q: Who owns releases? A: Dev Infra
+- Q: What’s the SLA? A: 99.9%
+<!-- Ch8 filler 001 -->
+<!-- Ch8 filler 002 -->
+<!-- Ch8 filler 003 -->
+<!-- Ch8 filler 004 -->
+<!-- Ch8 filler 005 -->
+<!-- Ch8 filler 006 -->
+<!-- Ch8 filler 007 -->
+<!-- Ch8 filler 008 -->
+<!-- Ch8 filler 009 -->
+<!-- Ch8 filler 010 -->
+<!-- Ch8 filler 011 -->
+<!-- Ch8 filler 012 -->
+<!-- Ch8 filler 013 -->
+<!-- Ch8 filler 014 -->
+<!-- Ch8 filler 015 -->
+<!-- Ch8 filler 016 -->
+<!-- Ch8 filler 017 -->
+<!-- Ch8 filler 018 -->
+<!-- Ch8 filler 019 -->
+<!-- Ch8 filler 020 -->
+<!-- Ch8 filler 021 -->
+<!-- Ch8 filler 022 -->
+<!-- Ch8 filler 023 -->
+<!-- Ch8 filler 024 -->
+<!-- Ch8 filler 025 -->
+<!-- Ch8 filler 026 -->
+<!-- Ch8 filler 027 -->
+<!-- Ch8 filler 028 -->
+<!-- Ch8 filler 029 -->
+<!-- Ch8 filler 030 -->

--- a/pipeline.sql
+++ b/pipeline.sql
@@ -1,0 +1,220 @@
+-- Long SQL with stage anchors. Keep each stage separated by filler blocks.
+
+-- [STAGE 1 START] prepare users
+CREATE TEMP TABLE t_users AS
+SELECT id, name, active
+FROM users
+WHERE deleted = false;
+-- S1 filler 001
+-- S1 filler 002
+-- S1 filler 003
+-- S1 filler 004
+-- S1 filler 005
+-- S1 filler 006
+-- S1 filler 007
+-- S1 filler 008
+-- S1 filler 009
+-- S1 filler 010
+-- S1 filler 011
+-- S1 filler 012
+-- S1 filler 013
+-- S1 filler 014
+-- S1 filler 015
+-- S1 filler 016
+-- S1 filler 017
+-- S1 filler 018
+-- S1 filler 019
+-- S1 filler 020
+-- S1 filler 021
+-- S1 filler 022
+-- S1 filler 023
+-- S1 filler 024
+-- S1 filler 025
+-- S1 filler 026
+-- S1 filler 027
+-- S1 filler 028
+-- S1 filler 029
+-- S1 filler 030
+-- [STAGE 1 END]
+
+-- [STAGE 2 START] filter active
+CREATE TEMP TABLE t_active AS
+SELECT id, name
+FROM t_users
+WHERE active = true;
+-- S2 filler 001
+-- S2 filler 002
+-- S2 filler 003
+-- S2 filler 004
+-- S2 filler 005
+-- S2 filler 006
+-- S2 filler 007
+-- S2 filler 008
+-- S2 filler 009
+-- S2 filler 010
+-- S2 filler 011
+-- S2 filler 012
+-- S2 filler 013
+-- S2 filler 014
+-- S2 filler 015
+-- S2 filler 016
+-- S2 filler 017
+-- S2 filler 018
+-- S2 filler 019
+-- S2 filler 020
+-- S2 filler 021
+-- S2 filler 022
+-- S2 filler 023
+-- S2 filler 024
+-- S2 filler 025
+-- S2 filler 026
+-- S2 filler 027
+-- S2 filler 028
+-- S2 filler 029
+-- S2 filler 030
+-- [STAGE 2 END]
+
+-- [STAGE 3 START] join purchases
+CREATE TEMP TABLE t_join AS
+SELECT a.id, a.name, p.amount
+FROM t_active a
+LEFT JOIN purchases p ON p.user_id = a.id;
+-- S3 filler 001
+-- S3 filler 002
+-- S3 filler 003
+-- S3 filler 004
+-- S3 filler 005
+-- S3 filler 006
+-- S3 filler 007
+-- S3 filler 008
+-- S3 filler 009
+-- S3 filler 010
+-- S3 filler 011
+-- S3 filler 012
+-- S3 filler 013
+-- S3 filler 014
+-- S3 filler 015
+-- S3 filler 016
+-- S3 filler 017
+-- S3 filler 018
+-- S3 filler 019
+-- S3 filler 020
+-- S3 filler 021
+-- S3 filler 022
+-- S3 filler 023
+-- S3 filler 024
+-- S3 filler 025
+-- S3 filler 026
+-- S3 filler 027
+-- S3 filler 028
+-- S3 filler 029
+-- S3 filler 030
+-- [STAGE 3 END]
+
+-- [STAGE 4 START] aggregate revenue
+CREATE TEMP TABLE t_rev AS
+SELECT id, SUM(amount) AS revenue
+FROM t_join
+GROUP BY id;
+-- S4 filler 001
+-- S4 filler 002
+-- S4 filler 003
+-- S4 filler 004
+-- S4 filler 005
+-- S4 filler 006
+-- S4 filler 007
+-- S4 filler 008
+-- S4 filler 009
+-- S4 filler 010
+-- S4 filler 011
+-- S4 filler 012
+-- S4 filler 013
+-- S4 filler 014
+-- S4 filler 015
+-- S4 filler 016
+-- S4 filler 017
+-- S4 filler 018
+-- S4 filler 019
+-- S4 filler 020
+-- S4 filler 021
+-- S4 filler 022
+-- S4 filler 023
+-- S4 filler 024
+-- S4 filler 025
+-- S4 filler 026
+-- S4 filler 027
+-- S4 filler 028
+-- S4 filler 029
+-- S4 filler 030
+-- [STAGE 4 END]
+
+-- [STAGE 5 START] write outputs
+INSERT INTO reporting.users_daily (id, name, revenue, dt)
+SELECT j.id, j.name, r.revenue, CURRENT_DATE
+FROM t_join j
+JOIN t_rev r USING (id);
+-- S5 filler 001
+-- S5 filler 002
+-- S5 filler 003
+-- S5 filler 004
+-- S5 filler 005
+-- S5 filler 006
+-- S5 filler 007
+-- S5 filler 008
+-- S5 filler 009
+-- S5 filler 010
+-- S5 filler 011
+-- S5 filler 012
+-- S5 filler 013
+-- S5 filler 014
+-- S5 filler 015
+-- S5 filler 016
+-- S5 filler 017
+-- S5 filler 018
+-- S5 filler 019
+-- S5 filler 020
+-- S5 filler 021
+-- S5 filler 022
+-- S5 filler 023
+-- S5 filler 024
+-- S5 filler 025
+-- S5 filler 026
+-- S5 filler 027
+-- S5 filler 028
+-- S5 filler 029
+-- S5 filler 030
+-- [STAGE 5 END]
+
+-- [STAGE 6 START] finalize
+VACUUM ANALYZE;
+-- S6 filler 001
+-- S6 filler 002
+-- S6 filler 003
+-- S6 filler 004
+-- S6 filler 005
+-- S6 filler 006
+-- S6 filler 007
+-- S6 filler 008
+-- S6 filler 009
+-- S6 filler 010
+-- S6 filler 011
+-- S6 filler 012
+-- S6 filler 013
+-- S6 filler 014
+-- S6 filler 015
+-- S6 filler 016
+-- S6 filler 017
+-- S6 filler 018
+-- S6 filler 019
+-- S6 filler 020
+-- S6 filler 021
+-- S6 filler 022
+-- S6 filler 023
+-- S6 filler 024
+-- S6 filler 025
+-- S6 filler 026
+-- S6 filler 027
+-- S6 filler 028
+-- S6 filler 029
+-- S6 filler 030
+-- [STAGE 6 END]


### PR DESCRIPTION
This pull request adds three long files: `engine.py`, `handbook.md`, and `pipeline.sql` which are structured for conflict testing with filler content ensuring sufficient separation between sections. Each file includes defined section anchors to make deterministic edits easier and contains placeholder content for testing purposes.

---

> This pull request was co-created with Cosine Genie

Original Task: [conflicts_test_github/luz9qluxlt5o](http://localhost:3000/tommy-personal/conflicts_test_github/task/luz9qluxlt5o)
Author: Tom Dowley
